### PR TITLE
Trying to debug rare segfaults in hb_slice.c

### DIFF
--- a/src/hydro_cdf.c
+++ b/src/hydro_cdf.c
@@ -627,7 +627,11 @@ int read_cdf_hdr(int cdfid, struct CDF_HDR *haddr)
    for (varid = 0; varid < nvars; ++varid) {
 
       error = nc_inq_varname(cdfid, varid, varname);
-
+      
+      /*
+      fprintf(stderr,"\nFound variable %s",varname);
+      */
+      
       found = 0;
       i = 0;
       while ((!found) && (i < MAXPROP)) {   /* Is it a property? */
@@ -636,8 +640,10 @@ int read_cdf_hdr(int cdfid, struct CDF_HDR *haddr)
       }
 
       if (found) {           
-
-         if (strncmp(mne, "de", 2) == 0) {       /* for depth, just get units */
+	/*
+	  fprintf(stderr,"\nFound %s",mne);
+	*/  
+	if (strncmp(mne, "de", 2) == 0) {       /* for depth, just get units */
             error = nc_get_att_text(cdfid, varid, "units", haddr->z_units);
          }
          else {

--- a/src/prop_subs.c
+++ b/src/prop_subs.c
@@ -531,7 +531,7 @@ int get_prop_indx(char *str)
               case '4':
                  return ((int) S4);
               default:
-                 return error;
+		return (error);
             } /* end switch */
             break;
       case 'T':
@@ -553,7 +553,7 @@ int get_prop_indx(char *str)
 	      case 'z' :
 		 return ((int) TZ);
               default:
-                 return error;
+		return (error);
             } /* end switch */
             break;
       case 'V':
@@ -572,12 +572,12 @@ int get_prop_indx(char *str)
                case 's' :
                    return ((int) VS);  
               default:
-                 return error;
+		return(error);
             } /* end switch */
             break;
 
       default:
-            return error;
+	return(error);
    } /* end switch */
 } /* end get_prop_indx() */
 


### PR DESCRIPTION
In prop_subs.c, look for 4 instances of "return (error)" which were changed from "return error".

In hb_slice.c, note that I retained a copy of the old, previously accepted version in hb_slice_reference.c.  In the block starting with:
if (++i == hptr->nprops) {
       /* SFG
       continue;
       */
I don't know if the { should be there or not.  The line "ip = hptr->prop_id[i];" may or may not be executed as needed.